### PR TITLE
Updated google_maps_flutter to ^0.5.21+8

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       name: google_maps_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.21+3"
+    version: "0.5.21+8"
   image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   geohash: ^0.2.1
   sqflite: ^1.1.5
   path_provider: ^1.1.0
-  google_maps_flutter: 0.5.21+3
+  google_maps_flutter: ^0.5.21+8
   meta: ^1.1.6
 
 dev_dependencies:


### PR DESCRIPTION
I updated the google_maps_flutter to latest as of now and added the `^` so that the plugin user won't have errors when google_maps_flutter is updated.